### PR TITLE
fix: migrate deprecated extensions/v1beta1 to networking.k8s.io/v1

### DIFF
--- a/pkg/kubernetes-utils.go
+++ b/pkg/kubernetes-utils.go
@@ -27,7 +27,7 @@ import (
 	goutils "github.com/keptn/go-utils/pkg/api/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	typesv1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -345,12 +345,12 @@ func PatchKeptnManagedNamespace(useInClusterConfig bool, namespace string) error
 
 // GetKeptnEndpointFromIngress returns the host of ingress object Keptn Installation
 func GetKeptnEndpointFromIngress(useInClusterConfig bool, namespace string, ingressName string) (string, error) {
-	var keptnIngress *v1beta1.Ingress
+	var keptnIngress *networkingv1.Ingress
 	clientset, err := GetClientset(useInClusterConfig)
 	if err != nil {
 		return "", err
 	}
-	keptnIngress, err = clientset.ExtensionsV1beta1().Ingresses(namespace).Get(context.TODO(), ingressName, metav1.GetOptions{})
+	keptnIngress, err = clientset.NetworkingV1().Ingresses(namespace).Get(context.TODO(), ingressName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Nitanshu Vashistha <nitanshu.vzard@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This PR migrates the deprecated extensions/v1beta1 to networking.k8s.io/v1. This was causing deprecations warnings. Please change the linked issue for more details.

### Related Issues
https://github.com/keptn/keptn/issues/4432

Fixes https://github.com/keptn/keptn/issues/4432

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

